### PR TITLE
Bump application cookbook version to resolve Sublime Text plugin error.

### DIFF
--- a/Cheffile
+++ b/Cheffile
@@ -2,7 +2,7 @@ site "http://community.opscode.com/api/v1"
 
 cookbook "homebrewalt",           :github => "kitchenplan/chef-homebrewalt",    :ref => "v1.8.3"
 cookbook "nodejs",                :github => "kitchenplan/chef-nodejs",         :ref => "v1.1"
-cookbook "applications",          :github => "kitchenplan/chef-applications",   :ref => "v2.0.2"
+cookbook "applications",          :github => "kitchenplan/chef-applications",   :ref => "v2.0.3"
 cookbook "osxdefaults",           :github => "kitchenplan/chef-osxdefaults",    :ref => "v1.0.2"
 cookbook "dotfiles",              :github => "kitchenplan/chef-dotfiles",       :ref => "v1.1"
 cookbook "drivers",               :github => "kitchenplan/chef-drivers",        :ref => "v1.0"


### PR DESCRIPTION
This was apparently caught upstream in the cookbook a few days ago, but the config repo hasn't caught up yet.  I stumbled across the error while testing the go script in Travis against the config test repo.

With this single change, Travis is able to build on Mavericks using the go script again.
